### PR TITLE
Fix Networking Bytes Sent graph

### DIFF
--- a/grafana/fly-instance.json
+++ b/grafana/fly-instance.json
@@ -2477,7 +2477,7 @@
                 "uid": "prometheus_on_fly"
               },
               "editorMode": "code",
-              "expr": "rate(fly_instance_net_recv_bytes{device='eth0', instance=\"$instance\"}) * 8",
+              "expr": "rate(fly_instance_net_sent_bytes{device='eth0', instance=\"$instance\"}) * 8",
               "hide": false,
               "legendFormat": "sent",
               "range": true,


### PR DESCRIPTION
The "Sent" time series on the Bytes graph was using the incorrect query `fly_instance_net_recv_bytes`, it should use `fly_instance_net_sent_bytes` instead.